### PR TITLE
Allow headsets with only a play button to pause the audio

### DIFF
--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/MediaPlayerService.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/MediaPlayerService.java
@@ -480,7 +480,8 @@ public class MediaPlayerService extends Service implements MediaPlayer.OnComplet
                                 buildNotification();
                                 break;
                             case KeyEvent.KEYCODE_MEDIA_PLAY:
-                                play();
+                                if (mMediaPlayer != null && mMediaPlayer.isPlaying()) pause();
+                                else play();
                                 buildNotification();
                                 break;
                         }


### PR DESCRIPTION
Similar to how  KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE already works to both pause and play, this will make both work with headsets that only have a play button.