### PR TITLE
Fix bug with seekbar when mediaPlayer hasn't finished loading

### DIFF
--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/PlayActivity.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/PlayActivity.java
@@ -425,12 +425,16 @@ public class PlayActivity extends AppCompatActivity {
      * Initialize the SeekBar
      */
     void initializeSeekBar(){
-        mSeekBar.setMax(mPlayer.getDuration()/1000);
-
         mRunnable = new Runnable() {
+            boolean firstRun = true;
+            
             @Override
             public void run() {
                 if(mPlayer!=null){
+                    if(firstRun) {
+                        mSeekBar.setMax(mPlayer.getDuration()/1000);
+                        firstRun = false;
+                    }
                     int currentPosition = mPlayer.getCurrentPosition();
                     mSeekBar.setProgress(currentPosition/1000);
                     mCompletedTimeTV.setText(Utils.formatTime(currentPosition, mAudioFile.getTime()));


### PR DESCRIPTION
This bug shows up when loading very big audio files (10h+).
When the intializeSeekBar() got called, mPlayer.getDuration() could report 0,
or a value smaller than the actual duration.