### PR TITLE
AutoRewind

### DIFF
--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/MediaPlayerService.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/MediaPlayerService.java
@@ -101,6 +101,7 @@ public class MediaPlayerService extends Service implements MediaPlayer.OnComplet
     // Settings flags
     private boolean mCoverFromMetadata;
     private boolean mTitleFromMetadata;
+    private int mAutorewind;
 
     /**
      * Service lifecycle methods
@@ -121,6 +122,7 @@ public class MediaPlayerService extends Service implements MediaPlayer.OnComplet
         mAutoplay = sharedPreferences.getBoolean(getString(R.string.settings_autoplay_key), Boolean.getBoolean(getString(R.string.settings_autoplay_default)));
         mCoverFromMetadata = sharedPreferences.getBoolean(getString(R.string.settings_cover_from_metadata_key), Boolean.getBoolean(getString(R.string.settings_cover_from_metadata_default)));
         mTitleFromMetadata = sharedPreferences.getBoolean(getString(R.string.settings_title_from_metadata_key), Boolean.getBoolean(getString(R.string.settings_title_from_metadata_default)));
+        mAutorewind = Integer.valueOf(sharedPreferences.getString(getString(R.string.settings_autorewind_key), getString(R.string.settings_autorewind_default)));
 
         // Perform one-time setup procedures
         // Manage incoming phone calls during playback.
@@ -708,7 +710,7 @@ public class MediaPlayerService extends Service implements MediaPlayer.OnComplet
 
     void play() {
         if (mMediaPlayer != null && !mMediaPlayer.isPlaying() && (mAutoplay || getCurrentPosition() != getDuration())) {
-            mMediaPlayer.seekTo(mMediaPlayer.getCurrentPosition());
+            mMediaPlayer.seekTo(mMediaPlayer.getCurrentPosition() - mAutorewind * 1000);
             mMediaPlayer.start();
             sendPlayStatusResult(MSG_PLAY);
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,9 @@
     <string name="settings_dark_label">Dark theme</string>
     <string name="settings_dark_key" translatable="false">settings_dark</string>
     <string name="settings_dark_default" translatable="false">false</string>
+    <string name="settings_autorewind_label">Autorewind time</string>
+    <string name="settings_autorewind_key" translatable="false">autorewind</string>
+    <string name="settings_autorewind_default" translatable="false">0</string>
 
     <!-- Intent data Strings -->
     <string name="album_id" translatable="false">album_id</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -24,6 +24,14 @@
         android:defaultValue="@string/settings_dark_default"
         android:key="@string/settings_dark_key"
         android:title="@string/settings_dark_label"/>
+    <EditTextPreference
+        android:defaultValue="@string/settings_autorewind_default"
+        android:inputType="number"
+        android:key="@string/settings_autorewind_key"
+        android:selectAllOnFocus="true"
+        android:singleLine="true"
+        android:maxLength="2"
+        android:title="@string/settings_autorewind_label" />
     <PreferenceCategory
         android:key="@string/settings_sleep_key"
         android:title="@string/settings_sleep_label">


### PR DESCRIPTION
Here is the autorewind functionality. 
Defaults to zero as discussed.
Autorewind is added to play() method of the MediaPlayerService so it's "rewinding" even if file starts from beginning. Since seekTo() jumps to zero if msc is negative this doesn't appear to be a problem. 

Let me know if any changes need to be made.
best
Lotl    