### PR TITLE
Fix incorrect behavior of autorewind function when autoplay option is enabled

### DIFF
--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/MediaPlayerService.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/MediaPlayerService.java
@@ -682,7 +682,9 @@ public class MediaPlayerService extends Service implements MediaPlayer.OnComplet
         mLockManager.acquireWakeLock();
 
         if (mMediaPlayer != null && !mMediaPlayer.isPlaying() && (autoplay || getCurrentPosition() != getDuration())) {
-            mMediaPlayer.seekTo(mMediaPlayer.getCurrentPosition() - autorewindTime * 1000);
+            if (getCurrentPosition() != getDuration()) {
+                mMediaPlayer.seekTo(mMediaPlayer.getCurrentPosition() - autorewindTime * 1000);
+            }
             mMediaPlayer.start();
             sendPlayStatusResult(MSG_PLAY);
             mediaSession.setActive(true);


### PR DESCRIPTION
When "autoplay" option is enabled and "autorewind time" is specified, after episode is finish, next episode start play final "autorewind time" seconds from the end of the episode, despite episode marked as "finished".
I suppose the more appropriate behavior is to skip episode marked as "finished" instead of playing the last "autorewind time" seconds.