### PR TITLE
Add option to not block cover art with track info

### DIFF
--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/PlayActivity.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/PlayActivity.java
@@ -37,6 +37,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.ListView;
+import android.widget.RelativeLayout;
 import android.widget.SeekBar;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -108,6 +109,7 @@ public class PlayActivity extends AppCompatActivity {
     // Settings flags
     private boolean mCoverFromMetadata;
     private boolean mTitleFromMetadata;
+    private boolean mCoverBelowTrackData;
     boolean mDarkTheme;
 
     // Shared preferences
@@ -146,6 +148,7 @@ public class PlayActivity extends AppCompatActivity {
         mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
         mCoverFromMetadata = mSharedPreferences.getBoolean(getString(R.string.settings_cover_from_metadata_key), Boolean.getBoolean(getString(R.string.settings_cover_from_metadata_default)));
         mTitleFromMetadata = mSharedPreferences.getBoolean(getString(R.string.settings_title_from_metadata_key), Boolean.getBoolean(getString(R.string.settings_title_from_metadata_default)));
+        mCoverBelowTrackData = mSharedPreferences.getBoolean(getString(R.string.settings_display_cover_below_track_data_key), Boolean.getBoolean(getString(R.string.settings_display_cover_below_track_data_default)));
         mLastSleepTime = mSharedPreferences.getInt(getString(R.string.preference_last_sleep_key), Integer.parseInt(getString(R.string.preference_last_sleep_val)));
         mDarkTheme = mSharedPreferences.getBoolean(getString(R.string.settings_dark_key), Boolean.getBoolean(getString(R.string.settings_dark_default)));
 
@@ -264,6 +267,13 @@ public class PlayActivity extends AppCompatActivity {
 
         boolean immediatePlayback = mSharedPreferences.getBoolean(getString(R.string.settings_immediate_playback_key), Boolean.getBoolean(getString(R.string.settings_immediate_playback_default)));
         if (immediatePlayback) playAudio();
+
+        // Show album cover below track data if the user set it as a preference
+        if (mCoverBelowTrackData) {
+            RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) mCoverIV.getLayoutParams();
+            params.addRule(RelativeLayout.BELOW, mAlbumTV.getId());
+            mCoverIV.setLayoutParams(params);
+        }
     }
 
     void initSkipButtons() {
@@ -324,11 +334,12 @@ public class PlayActivity extends AppCompatActivity {
 
     @Override
     protected void onRestart() {
-        // Recreate if theme, getCoverFromMetadata or getTitleFromMetadata has changed
+        // Recreate if theme, getCoverFromMetadata, getTitleFromMetadata, or coverImageBelowTrackData has changed
         boolean currentDarkTheme = mSharedPreferences.getBoolean(getString(R.string.settings_dark_key), Boolean.getBoolean(getString(R.string.settings_dark_default)));
         boolean currentGetCoverFromMetadata = mSharedPreferences.getBoolean(getString(R.string.settings_cover_from_metadata_key), Boolean.getBoolean(getString(R.string.settings_cover_from_metadata_default)));
         boolean currentGetTitleFromMetadata = mSharedPreferences.getBoolean(getString(R.string.settings_title_from_metadata_key), Boolean.getBoolean(getString(R.string.settings_title_from_metadata_default)));
-        if (mDarkTheme != currentDarkTheme || mCoverFromMetadata != currentGetCoverFromMetadata || mTitleFromMetadata != currentGetTitleFromMetadata) {
+        boolean currentCoverImageBelowTrackData = mSharedPreferences.getBoolean(getString(R.string.settings_display_cover_below_track_data_key), Boolean.getBoolean(getString(R.string.settings_display_cover_below_track_data_default)));
+        if (mDarkTheme != currentDarkTheme || mCoverFromMetadata != currentGetCoverFromMetadata || mTitleFromMetadata != currentGetTitleFromMetadata || mCoverBelowTrackData != currentCoverImageBelowTrackData) {
             recreate();
         }
         initSkipButtons();

--- a/app/src/main/res/values/donttranslate.xml
+++ b/app/src/main/res/values/donttranslate.xml
@@ -35,6 +35,8 @@
     <string name="settings_continue_until_end_default" translatable="false">false</string>
     <string name="settings_title_from_metadata_key" translatable="false">settings_title_from_metadata</string>
     <string name="settings_title_from_metadata_default" translatable="false">false</string>
+    <string name="settings_display_cover_below_track_data_key" translatable="false">cover_below_track_data</string>
+    <string name="settings_display_cover_below_track_data_default" translatable="false">false</string>
     <string name="settings_dark_key" translatable="false">settings_dark</string>
     <string name="settings_dark_default" translatable="false">false</string>
     <string name="settings_autorewind_key" translatable="false">autorewind</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
     <string name="settings_vibrate_shake_reset_label">Vibrate on reset by shake</string>
     <string name="settings_continue_until_end_label">Keep playing until end of current track</string>
     <string name="settings_title_from_metadata_label">Get track title from metadata</string>
+    <string name="settings_display_cover_below_track_data_label">Display cover image below track information</string>
     <string name="settings_dark_label">Dark theme</string>
     <string name="settings_autorewind_label">Autorewind time</string>
     <string name="settings_immediate_playback_label">Start playback immediately after selecting item</string>

--- a/app/src/main/res/xml-v26/settings.xml
+++ b/app/src/main/res/xml-v26/settings.xml
@@ -65,6 +65,11 @@
             android:title="@string/settings_title_from_metadata_label"
             android:singleLineTitle="false" />
         <SwitchPreference
+            android:defaultValue="@string/settings_display_cover_below_track_data_default"
+            android:key="@string/settings_display_cover_below_track_data_key"
+            android:title="@string/settings_display_cover_below_track_data_label"
+            android:singleLineTitle="false" />
+        <SwitchPreference
             android:defaultValue="@string/settings_dark_default"
             android:key="@string/settings_dark_key"
             android:title="@string/settings_dark_label"

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -58,6 +58,10 @@
             android:key="@string/settings_title_from_metadata_key"
             android:title="@string/settings_title_from_metadata_label" />
         <SwitchPreference
+            android:defaultValue="@string/settings_display_cover_below_track_data_default"
+            android:key="@string/settings_display_cover_below_track_data_key"
+            android:title="@string/settings_display_cover_below_track_data_label" />
+        <SwitchPreference
             android:defaultValue="@string/settings_dark_default"
             android:key="@string/settings_dark_key"
             android:title="@string/settings_dark_label" />


### PR DESCRIPTION
I've added an option in the settings under Display to no longer have the track information (folder and title) block the cover art of the audio file being played. I'm really new to Android programming so apologies if I made any mistakes 😀. I've tested my changes on my Pixel 6 Pro running Android 12 and it works as expected.  
Here's some screenshots of the changes:
As it is right now:  
![image](https://user-images.githubusercontent.com/23278147/155436281-a9b40909-0462-46bb-bdac-483c520d04ad.png)
With the changes I added, you can have the cover art be below the picture:  
![image](https://user-images.githubusercontent.com/23278147/155436345-dd3b0c8b-604e-4d86-b259-fad4e8a34f6b.png)
![image](https://user-images.githubusercontent.com/23278147/155436363-1685063d-701a-4be9-b880-a40647023c6d.png)

By the way, unrelated to the PR, but it may be useful to add a `.gitignore` file to the repo. I used Android Studio and it manually adds a `.idea` folder so it would be useful to other contributors if there's a gitignore file with common folders/files like that.