### PR TITLE
Add support for quantity/plural strings

### DIFF
--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/AlbumActivity.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/AlbumActivity.java
@@ -183,7 +183,8 @@ public class AlbumActivity extends AppCompatActivity implements LoaderManager.Lo
                 } else {
                     mSelectedTracks.remove(l);
                 }
-                String menuTitle = getResources().getString(R.string.items_selected, mSelectedTracks.size());
+                String menuTitle = getResources().getQuantityString(R.plurals.items_selected,
+                        mSelectedTracks.size(), mSelectedTracks.size());
                 actionMode.setTitle(menuTitle);
             }
 
@@ -582,7 +583,9 @@ public class AlbumActivity extends AppCompatActivity implements LoaderManager.Lo
 
         // Create a confirmation dialog
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        builder.setMessage(R.string.dialog_msg_delete_audio_from_db);
+        String confirmationMessage = getResources().getQuantityString(
+                R.plurals.dialog_msg_delete_audio_from_db, mSelectedTracks.size());
+        builder.setMessage(confirmationMessage);
 
         builder.setPositiveButton(R.string.dialog_msg_ok, (dialog, id) -> {
             // User clicked the "Ok" button, so delete the tracks from the database
@@ -593,7 +596,8 @@ public class AlbumActivity extends AppCompatActivity implements LoaderManager.Lo
                     deletionCount++;
                 }
             }
-            String deletedTracks = getResources().getString(R.string.tracks_deleted_from_db, deletionCount);
+            String deletedTracks = getResources().getQuantityString(R.plurals.tracks_deleted_from_db,
+                    deletionCount, deletionCount);
             Toast.makeText(getApplicationContext(), deletedTracks, Toast.LENGTH_LONG).show();
         });
 
@@ -618,7 +622,9 @@ public class AlbumActivity extends AppCompatActivity implements LoaderManager.Lo
 
         // Create a confirmation dialog
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        builder.setMessage(R.string.dialog_msg_delete_audio);
+        String confirmationMessage = getResources().getQuantityString(
+                R.plurals.dialog_msg_delete_audio, mSelectedTracks.size());
+        builder.setMessage(confirmationMessage);
 
         builder.setPositiveButton(R.string.dialog_msg_ok, (dialog, id) -> {
             // User clicked the "Ok" button, so delete selected audio files
@@ -640,7 +646,8 @@ public class AlbumActivity extends AppCompatActivity implements LoaderManager.Lo
                 if (deleted) deletionCount += 1;
             }
             mSynchronizer.updateDBTables();
-            String deletedTracks = getResources().getString(R.string.tracks_deleted, deletionCount);
+            String deletedTracks = getResources().getQuantityString(R.plurals.tracks_deleted,
+                    deletionCount, deletionCount);
             Toast.makeText(getApplicationContext(), deletedTracks, Toast.LENGTH_LONG).show();
             mSelectedTracks.clear();
         });

--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/DirectoryActivity.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/DirectoryActivity.java
@@ -114,7 +114,8 @@ public class DirectoryActivity extends AppCompatActivity  implements LoaderManag
                 } else {
                     mSelectedDirectories.remove(l);
                 }
-                String menuTitle = getResources().getString(R.string.items_selected, mSelectedDirectories.size());
+                String menuTitle = getResources().getQuantityString(R.plurals.items_selected,
+                        mSelectedDirectories.size(), mSelectedDirectories.size());
                 actionMode.setTitle(menuTitle);
             }
 
@@ -219,7 +220,8 @@ public class DirectoryActivity extends AppCompatActivity  implements LoaderManag
                 getContentResolver().delete(uri, null, null);
                 deletionCount++;
             }
-            String deletedTracks = getResources().getString(R.string.directories_deleted_from_db, deletionCount);
+            String deletedTracks = getResources().getQuantityString(R.plurals.directories_deleted_from_db,
+                    deletionCount, deletionCount);
             Toast.makeText(getApplicationContext(), deletedTracks, Toast.LENGTH_LONG).show();
         });
         builder.setNegativeButton(R.string.dialog_msg_cancel, (dialog, id) -> {

--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/MainActivity.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/MainActivity.java
@@ -155,7 +155,8 @@ public class MainActivity extends AppCompatActivity implements LoaderManager.Loa
                 } else {
                     mSelectedAlbums.remove(l);
                 }
-                String menuTitle = getResources().getString(R.string.items_selected, mSelectedAlbums.size());
+                String menuTitle = getResources().getQuantityString(R.plurals.items_selected,
+                        mSelectedAlbums.size(), mSelectedAlbums.size());
                 actionMode.setTitle(menuTitle);
             }
 
@@ -637,7 +638,9 @@ public class MainActivity extends AppCompatActivity implements LoaderManager.Loa
 
         // Create a confirmation dialog
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        builder.setMessage(R.string.dialog_msg_delete_album_from_db);
+        String confirmationMessage = getResources().getQuantityString(
+                R.plurals.dialog_msg_delete_album_from_db, mSelectedAlbums.size());
+        builder.setMessage(confirmationMessage);
         builder.setPositiveButton(R.string.dialog_msg_ok, (dialog, id) -> {
             // User clicked the "Ok" button, so delete the album and / or tracks from the database
             int deletionCount = 0;
@@ -645,7 +648,8 @@ public class MainActivity extends AppCompatActivity implements LoaderManager.Loa
                 boolean deleted = DBAccessUtils.deleteAlbumFromDB(MainActivity.this, albumId);
                 if (deleted) deletionCount++;
             }
-            String deletedAlbums = getResources().getString(R.string.albums_deleted_from_db, deletionCount);
+            String deletedAlbums = getResources().getQuantityString(R.plurals.albums_deleted_from_db,
+                    deletionCount, deletionCount);
             Toast.makeText(getApplicationContext(), deletedAlbums, Toast.LENGTH_LONG).show();
         });
         builder.setNegativeButton(R.string.dialog_msg_cancel, (dialog, id) -> {
@@ -670,7 +674,9 @@ public class MainActivity extends AppCompatActivity implements LoaderManager.Loa
 
         // Create a confirmation dialog
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        builder.setMessage(R.string.dialog_msg_delete_album);
+        String confirmationMessage = getResources().getQuantityString(
+                R.plurals.dialog_msg_delete_album, mSelectedAlbums.size());
+        builder.setMessage(confirmationMessage);
 
         builder.setPositiveButton(R.string.dialog_msg_ok, (dialog, id) -> {
             // Delete tracks within the selected albums
@@ -708,7 +714,9 @@ public class MainActivity extends AppCompatActivity implements LoaderManager.Loa
 
             // Update database tables and notify user about the deletion
             mSynchronizer.updateDBTables();
-            String deletedFiles = getResources().getString(R.string.files_deleted, albumDeletionCount, trackDeletionCount);
+            String deletedAlbums = getResources().getQuantityString(R.plurals.quant_albums, albumDeletionCount, albumDeletionCount);
+            String deletedTracks = getResources().getQuantityString(R.plurals.quant_tracks, trackDeletionCount, trackDeletionCount);
+            String deletedFiles = getResources().getString(R.string.album_and_tracks_deleted, deletedAlbums, deletedTracks);
             Toast.makeText(getApplicationContext(), deletedFiles, Toast.LENGTH_LONG).show();
             mSelectedAlbums.clear();
         });

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,11 +25,32 @@
     <string name="jumped_to_bookmark">Jumped to bookmark \"%s\" at %s.</string>
     <string name="bookmark_deleted">Bookmark deleted.</string>
     <string name="bookmark_added_toast">Added bookmark \"%s\" at %s.</string>
-    <string name="tracks_deleted">%d track(s) deleted.</string>
-    <string name="tracks_deleted_from_db">Deleted %d track(s) from your library.</string>
-    <string name="files_deleted">Deleted %d album(s) and %d track(s).</string>
-    <string name="albums_deleted_from_db">Deleted %d album(s) from your library.</string>
-    <string name="directories_deleted_from_db">Deleted %d directoy(s) from library</string>
+    <plurals name="tracks_deleted">
+        <item quantity="one">%d track deleted.</item>
+        <item quantity="other">%d tracks deleted.</item>
+    </plurals>
+    <plurals name="tracks_deleted_from_db">
+        <item quantity="one">Deleted %d track from your library.</item>
+        <item quantity="other">Deleted %d tracks from your library.</item>
+    </plurals>
+    <plurals name="quant_albums">
+        <item quantity="one">%d album</item>
+        <item quantity="other">%d albums</item>
+    </plurals>
+    <plurals name="quant_tracks">
+        <item quantity="one">%d track</item>
+        <item quantity="other">%d tracks</item>
+    </plurals>
+    <!-- First %s = "x albums" (quant_albums), second %s = "x tracks" (quant_tracks) -->
+    <string name="album_and_tracks_deleted">Deleted %s and %s.</string>
+    <plurals name="albums_deleted_from_db">
+        <item quantity="one">Deleted %d album from your library.</item>
+        <item quantity="other">Deleted %d albums from your library.</item>
+    </plurals>
+    <plurals name="directories_deleted_from_db">
+        <item quantity="one">Deleted %d directory from your library.</item>
+        <item quantity="other">Deleted %d directories from your library.</item>
+    </plurals>
     <string name="cannot_mark_as_not_started">Cannot mark currently playing track as not started.</string>
     <string name="cannot_mark_as_completed">Cannot mark currently playing track as completed.</string>
     <string name="path">Path: %s</string>
@@ -101,7 +122,10 @@
     <string name="remove_from_library">Remove from library</string>
     <string name="mark_as_not_started">Mark as not started</string>
     <string name="mark_as_completed">Mark as completed</string>
-    <string name="items_selected">%d selected</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d selected</item>
+        <item quantity="other">%d selected</item>
+    </plurals>
     <string name="mark_all_as_not_started">Mark all tracks as not started</string>
     <string name="mark_all_as_completed">Mark all tracks as completed</string>
     <string name="playback_speed">Playback speed</string>
@@ -121,10 +145,22 @@
     <string name="dialog_msg_close">Close</string>
     <string name="dialog_msg_delete">Delete</string>
     <string name="dialog_msg_goto">Enter the time to which you want to jump</string>
-    <string name="dialog_msg_delete_album">Are you sure you want to delete the selected directory(s) and their contents?</string>
-    <string name="dialog_msg_delete_album_from_db">Are you sure you want to remove the selected album(s) and their contents from your library? This operation will only be performed for files that do not exist anymore in the file system.</string>
-    <string name="dialog_msg_delete_audio">Are you sure you want to delete the selected track(s)?</string>
-    <string name="dialog_msg_delete_audio_from_db">Are you sure you want to remove the selected track(s) from the library? This operation will only be performed for files that do not exist anymore in the file system.</string>
+    <plurals name="dialog_msg_delete_album">
+        <item quantity="one">Are you sure you want to delete the selected directory and its contents?</item>
+        <item quantity="other">Are you sure you want to delete the selected directories and their contents?</item>
+    </plurals>
+    <plurals name="dialog_msg_delete_album_from_db">
+        <item quantity="one">Are you sure you want to remove the selected album and its contents from your library? This operation will only be performed for files that do not exist anymore in the file system.</item>
+        <item quantity="other">Are you sure you want to remove the selected albums and their contents from your library? This operation will only be performed for files that do not exist anymore in the file system..</item>
+    </plurals>
+    <plurals name="dialog_msg_delete_audio">
+        <item quantity="one">Are you sure you want to delete the selected track?</item>
+        <item quantity="other">Are you sure you want to delete the selected tracks?</item>
+    </plurals>
+    <plurals name="dialog_msg_delete_audio_from_db">
+        <item quantity="one">Are you sure you want to remove the selected track from the library? This operation will only be performed for files that do not exist anymore in the file system.</item>
+        <item quantity="other">Are you sure you want to remove the selected tracks from the library? This operation will only be performed for files that do not exist anymore in the file system..</item>
+    </plurals>
     <string name="dialog_msg_delete_bookmark">Delete this bookmark?</string>
     <string name="dialog_msg_delete_directory_from_db">Are you sure you want to remove the selected directory from your library? This will also delete its albums, audio files and bookmarks from your library.</string>
 


### PR DESCRIPTION
This adds support for quantity (i.e., plural) strings. For example, instead of showing `x track(s) deleted`, show, e.g., `1 track deleted` or `7 tracks deleted`, depending on the number of tracks (some languages may also have *more than two* plural forms, and this is automatically supported).

See the Android documentation for quantity strings for information:
https://developer.android.com/guide/topics/resources/string-resource#Plurals

Note that strings like `%d selected`, which doesn’t differ depending on %d in English, also needs to be made into quantity strings, as other languages/translations may have different rules.

# Additional notes
I have built and tested AudioAnchor with these changes (and using an updated Norwegian Nynorsk translation with plural forms, which I’ll send as a separate PR when everything is merged), and it seems to work fine. But I haven’t done *any* Android programming before, so please double check that everything is correct.

The old `files_deleted` string (now `album_and_tracks_deleted`) was problematic, as it contained *two* substrings which needed plural forms:

> Deleted %d album(s) and %d track(s).

I tried to solve this by splitting the string into three strings, one quantity string for the album(s), one quantity string for the track(s) and a string concatenating these two strings (`Deleted %s and %s.`). This isn’t an ideal solution, and I’m not sure if it’ll work for all languages (the words ‘Deleted’ and ‘and’ may potentially need different translations depending on the number of albums and tracks for some languages), but it was the best solution I could think of. BTW, I wasn’t able to test this solution, as I couldn’t actually find a way to actually trigger the string in AudioAnchor.

I haven’t made any other changes to the strings (except fixing the misspelling in `directoy(s)`), but I did find one inconsistency. Removing files/tracks/albums/ from the DB is sometimes called ‘removing’ (`Remove from library`, as opposed to `Delete from device`) and sometimes called ‘deleting’ (`Deleted %d tracks from your library.`). I think it would be better to be consistent here and use ‘delete’ only for deleting files/folders from disk (a dangerous operation) and ‘remove’ for removing stuff from the DB (no so dangerous, as no files are actually deleted).