### PR TITLE
Add webp cover art support

### DIFF
--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/utils/Utils.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/utils/Utils.java
@@ -41,7 +41,7 @@ public class Utils {
         FilenameFilter imgFilter = (dir1, filename) -> {
             File sel = new File(dir1, filename);
             // Only list files that are readable and images
-            return sel.getName().endsWith(".jpg") || sel.getName().endsWith(".jpeg") || sel.getName().endsWith(".png");
+            return sel.getName().endsWith(".jpg") || sel.getName().endsWith(".jpeg") || sel.getName().endsWith(".png") || sel.getName().endsWith(".webp");
         };
 
         String[] fileList = dir.list(imgFilter);


### PR DESCRIPTION
As the title says, this adds support for cover art to be in the webp format. Tested on my Pixel 6 Pro with Android 12, and my album with a webp image displayed correctly after a refresh.