### PR TITLE
downscale bitmaps larger than 5000*5000 px in area

### DIFF
--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/utils/BitmapUtils.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/utils/BitmapUtils.java
@@ -15,6 +15,7 @@ import java.io.File;
 public class BitmapUtils {
 
     private static final String LOG_TAG = Utils.class.getName();
+    private static final int MAX_BITMAP_SIZE = 100000000;
 
     /**
      * Set the image of the given image view to the given image file, return false if the file does
@@ -30,6 +31,10 @@ public class BitmapUtils {
         }
         Bitmap bmp = decodeSampledBitmap(file, reqSize, reqSize);
         if (bmp != null) {
+            while (bmp.getByteCount() > MAX_BITMAP_SIZE) {
+                Log.d(LOG_TAG, "Bitmap was probably too large at " + String.valueOf(bmp.getByteCount()) + " bytes, resizing to 1/2 size.");
+                bmp = Bitmap.createScaledBitmap(bmp, bmp.getWidth() / 2, bmp.getHeight() / 2, false);
+            }
             iv.setImageBitmap(bmp);
         }
     }


### PR DESCRIPTION
Device: Pixel 6 Pro on Android 12
Problem: 
I had a crash occurring whenever I would open up a certain audio track because the image I have in the folder is 4896x6533 pixels large (lol...). Crash output:  
```
2022-06-19 09:45:33.067 24203-24203/com.prangesoftwaresolutions.audioanchor E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.prangesoftwaresolutions.audioanchor, PID: 24203
    java.lang.RuntimeException: Canvas: trying to draw too large(127942272bytes) bitmap.
        at android.graphics.RecordingCanvas.throwIfCannotDraw(RecordingCanvas.java:266)
        at android.graphics.BaseRecordingCanvas.drawBitmap(BaseRecordingCanvas.java:94)
        at android.graphics.drawable.BitmapDrawable.draw(BitmapDrawable.java:549)
        at android.widget.ImageView.onDraw(ImageView.java:1442)
        at android.view.View.draw(View.java:22645)
        at android.view.View.updateDisplayListIfDirty(View.java:21520)
        at android.view.View.draw(View.java:22376)
        at android.view.ViewGroup.drawChild(ViewGroup.java:4528)
        at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4289)
        at android.view.View.updateDisplayListIfDirty(View.java:21511)
        at android.view.View.draw(View.java:22376)
        at android.view.ViewGroup.drawChild(ViewGroup.java:4528)
        at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4289)
        at android.view.View.updateDisplayListIfDirty(View.java:21511)
        at android.view.View.draw(View.java:22376)
        at android.view.ViewGroup.drawChild(ViewGroup.java:4528)
        at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4289)
        at android.view.View.updateDisplayListIfDirty(View.java:21511)
        at android.view.View.draw(View.java:22376)
        at android.view.ViewGroup.drawChild(ViewGroup.java:4528)
        at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4289)
        at android.view.View.updateDisplayListIfDirty(View.java:21511)
        at android.view.View.draw(View.java:22376)
        at android.view.ViewGroup.drawChild(ViewGroup.java:4528)
        at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4289)
        at android.view.View.updateDisplayListIfDirty(View.java:21511)
        at android.view.View.draw(View.java:22376)
        at android.view.ViewGroup.drawChild(ViewGroup.java:4528)
        at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4289)
        at android.view.View.updateDisplayListIfDirty(View.java:21511)
        at android.view.View.draw(View.java:22376)
        at android.view.ViewGroup.drawChild(ViewGroup.java:4528)
        at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4289)
        at android.view.View.draw(View.java:22648)
        at com.android.internal.policy.DecorView.draw(DecorView.java:820)
        at android.view.View.updateDisplayListIfDirty(View.java:21520)
        at android.view.ThreadedRenderer.updateViewTreeDisplayList(ThreadedRenderer.java:534)
        at android.view.ThreadedRenderer.updateRootDisplayList(ThreadedRenderer.java:540)
        at android.view.ThreadedRenderer.draw(ThreadedRenderer.java:616)
        at android.view.ViewRootImpl.draw(ViewRootImpl.java:4438)
        at android.view.ViewRootImpl.performDraw(ViewRootImpl.java:4166)
        at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:3326)
        at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:2143)
        at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:8665)
        at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1037)
        at android.view.Choreographer.doCallbacks(Choreographer.java:845)
        at android.view.Choreographer.doFrame(Choreographer.java:780)
        at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1022)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7839)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```
Solution:  
I decided to halve bitmap sizes when they're over 5000\*5000 pixels in area (arbitrarily chosen, this represents a bitmap size of 100 million bytes). Tested it on my phone, and now the file doesn't crash the app anymore, and displays the image as I'd expect. Tried at first to catch the RuntimeException but seems that you can't do that in a setImageBitmap call. Probably a niche edgecase so I think this would be sufficient, halving a >5000px\*5000px image should still give a pretty nice image anyway.