### PR TITLE
fix issue #191 (incorrect time display for big durations)

### DIFF
--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/utils/Utils.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/utils/Utils.java
@@ -66,7 +66,6 @@ public class Utils {
 
         seconds = seconds % 60;
         minutes = minutes % 60;
-        hours = hours % 60;
 
         long hoursFullTime = fullTime / (60 * 60 * 1000);
 


### PR DESCRIPTION
This fixes flackbash/AudioAnchor#191.

(NB: The current issue title "Progress time incorrect when total time is over 24h" is misleading, though. Durations less than 60 hours should not have been affected by the bug.)