### PR TITLE
Should mServiceBound be set to false in AlbumActivity's onServiceDisconnected?

### DIFF
--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/AlbumActivity.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/AlbumActivity.java
@@ -454,6 +454,7 @@ public class AlbumActivity extends AppCompatActivity implements LoaderManager.Lo
 
         @Override
         public void onServiceDisconnected(ComponentName name) {
+            mServiceBound = false;
             Log.e("AlbumActivity", "OnServiceDisconnected called");
         }
     };


### PR DESCRIPTION
I noticed that all three primary activities use the `ServiceConnection`, though in [MainActivity] and [PlayActivity] we have
```
public void onServiceDisconnected(ComponentName name) {
    mServiceBound = false;
    // ...
```
and in `AlbumActivity` only a log message is generated. It this a bug?

[MainActivity]: https://github.com/flackbash/AudioAnchor/blob/51660c71a25b1a35395e8dbebfe7ca49526a4a08/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/MainActivity.java#L500
[PlayActivity]: https://github.com/flackbash/AudioAnchor/blob/51660c71a25b1a35395e8dbebfe7ca49526a4a08/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/PlayActivity.java#L454