### PR TITLE
External storage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,8 +8,8 @@ android {
         applicationId = "com.prangesoftwaresolutions.audioanchor"
         minSdk = 21
         targetSdk = 35
-        versionCode = 31
-        versionName = "2.4.0"
+        versionCode = 32
+        versionName = "2.5.0"
     }
     buildTypes {
         release {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,12 +15,16 @@ android {
         release {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+            resValue("string", "app_package_uri",
+                "package:" + android.defaultConfig.applicationId)
         }
 
         debug {
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-DEBUG"
             isDebuggable = true
+            resValue("string", "app_package_uri",
+                "package:" + android.defaultConfig.applicationId + applicationIdSuffix)
         }
     }
     compileOptions {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="29" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/DirectoryActivity.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/DirectoryActivity.java
@@ -4,6 +4,7 @@ import android.app.LoaderManager;
 import android.content.ContentUris;
 import android.content.CursorLoader;
 import android.content.Loader;
+import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Environment;
@@ -149,6 +150,12 @@ public class DirectoryActivity extends AppCompatActivity  implements LoaderManag
             if (allowAddDirectory(newDirectory)) {
                 mSynchronizer.addDirectory(newDirectory);
             }
+        });
+        fileDialog.addDefaultDirectoryListener(directory -> {
+            SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(this).edit();
+            editor.putString(getString(R.string.settings_directory_picker_initial_path_key), directory.getAbsolutePath());
+            editor.apply();
+            fileDialog.showDialog();
         });
         fileDialog.showDialog();
     }

--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/DirectoryActivity.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/activities/DirectoryActivity.java
@@ -19,6 +19,7 @@ import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
+import androidx.preference.PreferenceManager;
 
 import com.nambimobile.widgets.efab.FabOption;
 import com.prangesoftwaresolutions.audioanchor.R;
@@ -135,7 +136,12 @@ public class DirectoryActivity extends AppCompatActivity  implements LoaderManag
     }
 
     private void addDirectory(boolean isParentDirectory) {
-        File baseDirectory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC);
+        String baseDirectoryPref = PreferenceManager.getDefaultSharedPreferences(this).getString(
+                getString(R.string.settings_directory_picker_initial_path_key), getString(R.string.settings_directory_picker_initial_path_default));
+        File baseDirectory = baseDirectoryPref.isBlank()
+                ? Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC)
+                : new File(baseDirectoryPref);
+
         FileDialog fileDialog = new FileDialog(this, baseDirectory, true, null, this);
         fileDialog.addDirectoryListener(directory -> {
             Directory.Type directoryType = isParentDirectory ? Directory.Type.PARENT_DIR : Directory.Type.SUB_DIR;

--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/dialogs/FileDialog.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/dialogs/FileDialog.java
@@ -47,6 +47,7 @@ public class FileDialog {
 
     private final ListenerList<FileSelectedListener> fileListenerList = new ListenerList<>();
     private final ListenerList<DirectorySelectedListener> dirListenerList = new ListenerList<>();
+    private final ListenerList<DirectorySelectedListener> defaultDirListenerList = new ListenerList<>();
     private final Activity activity;
     private final boolean mSelectDirectory;
     private String fileEndsWith;
@@ -85,6 +86,10 @@ public class FileDialog {
             builder.setPositiveButton(R.string.dialog_msg_select_dir, (dialog1, which) -> {
                 Log.d(TAG, currentPath.getPath());
                 fireDirectorySelectedEvent(currentPath);
+            });
+            builder.setNeutralButton(R.string.dialog_msg_set_default_dir, (dialog1, which) -> {
+                Log.d(TAG, currentPath.getPath());
+                fireDefaultDirectorySelectedEvent(currentPath);
             });
         }
         builder.setNegativeButton(R.string.dialog_msg_cancel, (dialog1, which) -> {
@@ -131,6 +136,14 @@ public class FileDialog {
         dirListenerList.remove(listener);
     }
 
+    public void addDefaultDirectoryListener(DirectorySelectedListener listener) {
+        defaultDirListenerList.add(listener);
+    }
+
+    public void removeDefaultDirectoryListener(DirectorySelectedListener listener) {
+        defaultDirListenerList.remove(listener);
+    }
+
     /**
      * Show file dialog
      */
@@ -144,6 +157,10 @@ public class FileDialog {
 
     private void fireDirectorySelectedEvent(final File directory) {
         dirListenerList.fireEvent(listener -> listener.directorySelected(directory));
+    }
+
+    private void fireDefaultDirectorySelectedEvent(final File directory) {
+        defaultDirListenerList.fireEvent(listener -> listener.directorySelected(directory));
     }
 
     private void loadFileList(File path) {

--- a/app/src/main/java/com/prangesoftwaresolutions/audioanchor/dialogs/FileDialog.java
+++ b/app/src/main/java/com/prangesoftwaresolutions/audioanchor/dialogs/FileDialog.java
@@ -4,7 +4,10 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
+import android.os.Build;
 import android.os.Environment;
+import android.os.storage.StorageManager;
+import android.os.storage.StorageVolume;
 import androidx.annotation.NonNull;
 import android.util.Log;
 import android.view.View;
@@ -57,9 +60,22 @@ public class FileDialog {
         this.activity = activity;
         setFileEndsWith(fileEndsWith);
         mSelectDirectory = selectDirectory;
+        mContext = context;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            StorageManager storageManager = (StorageManager) mContext.getSystemService(Context.STORAGE_SERVICE);
+            for (StorageVolume v: storageManager.getStorageVolumes()) {
+                File volumePath = v.getDirectory();
+                if (volumePath != null && volumePath.canRead()) {
+                    ensureReachabilityOfPath(volumePath);
+                }
+            }
+        } else {
+            ensureReachabilityOfPath(Environment.getExternalStorageDirectory());
+        }
+
         if (!initialPath.exists()) initialPath = Environment.getExternalStorageDirectory();
         loadFileList(initialPath);
-        mContext = context;
     }
 
     /**
@@ -216,6 +232,20 @@ public class FileDialog {
 
     private void setFileEndsWith(String fileEndsWith) {
         this.fileEndsWith = fileEndsWith != null ? fileEndsWith.toLowerCase() : null;
+    }
+
+    private void ensureReachabilityOfPath(File path) {
+        Log.i("FileDialog.java", "Ensure reachability of " + path);
+        String filename = path.getName();
+        File parent = path.getParentFile();
+        while (parent != null) {
+            HashSet<String> childDirs = childDirectories.get(parent.getAbsolutePath());
+            if (childDirs == null) childDirs = new HashSet<>();
+            childDirs.add(filename);
+            childDirectories.put(parent.getAbsolutePath(), childDirs);
+            filename = parent.getName();
+            parent = parent.getParentFile();
+        }
     }
 }
 

--- a/app/src/main/res/values/donttranslate.xml
+++ b/app/src/main/res/values/donttranslate.xml
@@ -73,6 +73,8 @@
     <string name="settings_notification_backward_button_key" translatable="false">notification_backward_button</string>
     <string name="settings_notification_forward_button_key" translatable="false">notification_forward_button</string>
     <string name="settings_skip_interval" translatable="false">%d s</string>
+    <string name="settings_directory_picker_initial_path_key" translatable="false">directory_picker_initial_path</string>
+    <string name="settings_directory_picker_initial_path_default" translatable="false" />
 
     <!-- Intent data Strings -->
     <string name="album_id" translatable="false">album_id</string>

--- a/app/src/main/res/values/donttranslate.xml
+++ b/app/src/main/res/values/donttranslate.xml
@@ -73,6 +73,7 @@
     <string name="settings_notification_backward_button_key" translatable="false">notification_backward_button</string>
     <string name="settings_notification_forward_button_key" translatable="false">notification_forward_button</string>
     <string name="settings_skip_interval" translatable="false">%d s</string>
+    <string name="settings_manage_external_storage_key" translatable="false">manage_external_storage</string>
     <string name="settings_directory_picker_initial_path_key" translatable="false">directory_picker_initial_path</string>
     <string name="settings_directory_picker_initial_path_default" translatable="false" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,7 +100,9 @@
     <string name="settings_notification_backward_button">Notification backward button</string>
     <string name="settings_notification_forward_button">Notification forward button</string>
     <string name="settings_skip_interval_msg">Skip interval for %s</string>
+    <string name="settings_manage_external_storage_label">Request \"All files access\"</string>
     <string name="settings_directory_picker_initial_path_label">Initial directory picker path</string>
+
 
     <!-- Layout Texts -->
     <string name="title">Title</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,7 @@
     <string name="settings_notification_backward_button">Notification backward button</string>
     <string name="settings_notification_forward_button">Notification forward button</string>
     <string name="settings_skip_interval_msg">Skip interval for %s</string>
+    <string name="settings_directory_picker_initial_path_label">Initial directory picker path</string>
 
     <!-- Layout Texts -->
     <string name="title">Title</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,7 +142,8 @@
     <string name="add_directory">You can select a single directory that contains audio files or a parent directory that contains several directories containing audio files.</string>
 
     <!-- Dialog strings -->
-    <string name="dialog_msg_select_dir">Select directory</string>
+    <string name="dialog_msg_select_dir">Select</string>
+    <string name="dialog_msg_set_default_dir">Set default</string>
     <string name="dialog_msg_sleep_timer">Enter the number of minutes for which the player should keep playing</string>
     <string name="dialog_msg_ok">OK</string>
     <string name="dialog_msg_cancel">Cancel</string>

--- a/app/src/main/res/xml-v26/settings.xml
+++ b/app/src/main/res/xml-v26/settings.xml
@@ -178,6 +178,13 @@
             android:key="@string/settings_keep_deleted_key"
             android:title="@string/settings_keep_deleted_label"
             android:singleLineTitle="false" />
+
+        <EditTextPreference
+            android:defaultValue="@string/settings_directory_picker_initial_path_default"
+            android:key="@string/settings_directory_picker_initial_path_key"
+            android:title="@string/settings_directory_picker_initial_path_label"
+            android:singleLine="true"
+            android:singleLineTitle="false"/>
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/app/src/main/res/xml-v30/settings.xml
+++ b/app/src/main/res/xml-v30/settings.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <PreferenceCategory android:title="@string/settings_playback_category">
+
+        <SwitchPreference
+            android:defaultValue="@string/settings_autoplay_default"
+            android:key="@string/settings_autoplay_key"
+            android:title="@string/settings_autoplay_label"
+            android:singleLineTitle="false"/>
+        <SwitchPreference
+            android:defaultValue="@string/settings_autoplay_restart_default"
+            android:key="@string/settings_autoplay_restart_key"
+            android:title="@string/settings_autoplay_restart_label"
+            android:singleLineTitle="false"/>
+        <EditTextPreference
+            android:defaultValue="@string/settings_autorewind_default"
+            android:inputType="number"
+            android:key="@string/settings_autorewind_key"
+            android:selectAllOnFocus="true"
+            android:singleLine="true"
+            android:maxLength="2"
+            android:title="@string/settings_autorewind_label"
+            android:summary="@string/settings_autorewind_default"
+            android:singleLineTitle="false"/>
+        <SwitchPreference
+            android:defaultValue="@string/settings_immediate_playback_default"
+            android:key="@string/settings_immediate_playback_key"
+            android:title="@string/settings_immediate_playback_label"
+            android:singleLineTitle="false"/>
+
+        <SwitchPreference
+            android:defaultValue="@string/settings_duck_audio_default"
+            android:key="@string/settings_duck_audio_key"
+            android:title="@string/settings_duck_audio_label"
+            android:singleLineTitle="false"/>
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/settings_display_category">
+
+        <ListPreference
+            android:defaultValue="@string/settings_sort_order_by_directory_value"
+            android:key="@string/settings_sort_order_key"
+            android:title="@string/settings_sort_order_label"
+            android:entries="@array/sort_order_label_array"
+            android:entryValues="@array/sort_order_value_array"/>
+        <SwitchPreference
+            android:defaultValue="@string/settings_progress_percentage_default"
+            android:key="@string/settings_progress_percentage_key"
+            android:title="@string/settings_progress_percentage_label"
+            android:singleLineTitle="false" />
+        <SwitchPreference
+            android:defaultValue="@string/settings_cover_on_lockscreen_default"
+            android:key="@string/settings_cover_on_lockscreen_key"
+            android:title="@string/settings_cover_on_lockscreen_label"
+            android:singleLineTitle="false" />
+        <SwitchPreference
+            android:defaultValue="@string/settings_cover_from_metadata_default"
+            android:key="@string/settings_cover_from_metadata_key"
+            android:title="@string/settings_cover_from_metadata_label"
+            android:singleLineTitle="false"/>
+        <SwitchPreference
+            android:defaultValue="@string/settings_title_from_metadata_default"
+            android:key="@string/settings_title_from_metadata_key"
+            android:title="@string/settings_title_from_metadata_label"
+            android:singleLineTitle="false" />
+        <SwitchPreference
+            android:defaultValue="@string/settings_display_cover_below_track_data_default"
+            android:key="@string/settings_display_cover_below_track_data_key"
+            android:title="@string/settings_display_cover_below_track_data_label"
+            android:singleLineTitle="false" />
+        <ListPreference
+            android:defaultValue="@string/settings_dark_theme_system_value"
+            android:key="@string/settings_dark_key"
+            android:title="@string/settings_dark_label"
+            android:entries="@array/dark_theme_label_array"
+            android:entryValues="@array/dark_theme_value_array"/>
+        <SwitchPreference
+            android:defaultValue="@string/settings_show_hidden_default"
+            android:key="@string/settings_show_hidden_key"
+            android:title="@string/settings_show_hidden_label"
+            android:singleLineTitle="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/settings_skip_intervals_category">
+        <com.prangesoftwaresolutions.audioanchor.helpers.SkipIntervalPreference
+            android:defaultValue="@string/settings_skip_interval_big_default"
+            android:dialogTitle="@string/settings_backward_button_1"
+            android:key="@string/settings_backward_button_1_key"
+            android:title="@string/settings_backward_button_1"
+            android:singleLineTitle="false" />
+        <com.prangesoftwaresolutions.audioanchor.helpers.SkipIntervalPreference
+            android:defaultValue="@string/settings_skip_interval_small_default"
+            android:dialogTitle="@string/settings_backward_button_2"
+            android:key="@string/settings_backward_button_2_key"
+            android:title="@string/settings_backward_button_2"
+            android:singleLineTitle="false" />
+        <com.prangesoftwaresolutions.audioanchor.helpers.SkipIntervalPreference
+            android:defaultValue="@string/settings_skip_interval_small_default"
+            android:dialogTitle="@string/settings_forward_button_1"
+            android:key="@string/settings_forward_button_1_key"
+            android:title="@string/settings_forward_button_1"
+            android:singleLineTitle="false" />
+        <com.prangesoftwaresolutions.audioanchor.helpers.SkipIntervalPreference
+            android:defaultValue="@string/settings_skip_interval_big_default"
+            android:dialogTitle="@string/settings_forward_button_2"
+            android:key="@string/settings_forward_button_2_key"
+            android:title="@string/settings_forward_button_2"
+            android:singleLineTitle="false" />
+
+        <com.prangesoftwaresolutions.audioanchor.helpers.SkipIntervalPreference
+            android:defaultValue="@string/settings_skip_interval_big_default"
+            android:dialogTitle="@string/settings_notification_backward_button"
+            android:key="@string/settings_notification_backward_button_key"
+            android:title="@string/settings_notification_backward_button"
+            android:singleLineTitle="false" />
+        <com.prangesoftwaresolutions.audioanchor.helpers.SkipIntervalPreference
+            android:defaultValue="@string/settings_skip_interval_big_default"
+            android:dialogTitle="@string/settings_notification_forward_button"
+            android:key="@string/settings_notification_forward_button_key"
+            android:title="@string/settings_notification_forward_button"
+            android:singleLineTitle="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/settings_sleep_timer_category">
+
+        <EditTextPreference
+            android:defaultValue="@string/settings_sleep_fadeout_default"
+            android:inputType="number"
+            android:key="@string/settings_sleep_fadeout_key"
+            android:selectAllOnFocus="true"
+            android:singleLine="true"
+            android:maxLength="3"
+            android:title="@string/settings_sleep_fadeout_label"
+            android:summary="@string/settings_sleep_fadeout_default"
+            android:singleLineTitle="false"/>
+        <SwitchPreference
+            android:defaultValue="@string/settings_shake_default"
+            android:key="@string/settings_shake_key"
+            android:title="@string/settings_shake_label"
+            android:singleLineTitle="false" />
+        <SwitchPreference
+            android:defaultValue="@string/settings_vibrate_shake_reset_default"
+            android:key="@string/settings_vibrate_shake_reset_key"
+            android:title="@string/settings_vibrate_shake_reset_label"
+            android:singleLineTitle="false"/>
+        <SeekBarPreference
+            android:defaultValue="@string/settings_shake_sensitivity_default"
+            android:max="@string/settings_shake_sensitivity_max"
+            android:key="@string/settings_shake_sensitivity_key"
+            android:title="@string/settings_shake_sensitivity_label"
+            android:singleLineTitle="false" />
+        <SwitchPreference
+            android:defaultValue="@string/settings_continue_until_end_default"
+            android:key="@string/settings_continue_until_end_key"
+            android:title="@string/settings_continue_until_end_label"
+            android:singleLineTitle="false"/>
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/settings_bookmarks_category">
+
+        <SwitchPreference
+            android:defaultValue="@string/settings_quick_bookmark_default"
+            android:key="@string/settings_quick_bookmark_key"
+            android:title="@string/settings_quick_bookmark_label"
+            android:singleLineTitle="false" />
+        <SwitchPreference
+            android:defaultValue="@string/settings_add_last_play_position_bookmark_default"
+            android:key="@string/settings_add_last_play_position_bookmark_key"
+            android:title="@string/settings_add_last_play_position_bookmark_label"
+            android:singleLineTitle="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/settings_miscellaneous_category">
+
+        <SwitchPreference
+            android:defaultValue="@string/settings_keep_deleted_default"
+            android:key="@string/settings_keep_deleted_key"
+            android:title="@string/settings_keep_deleted_label"
+            android:singleLineTitle="false" />
+
+        <EditTextPreference
+            android:defaultValue="@string/settings_directory_picker_initial_path_default"
+            android:key="@string/settings_directory_picker_initial_path_key"
+            android:title="@string/settings_directory_picker_initial_path_label"
+            android:singleLine="true"
+            android:singleLineTitle="false"/>
+        <Preference
+            android:key="@string/settings_manage_external_storage_key"
+            android:title="@string/settings_manage_external_storage_label">
+            <intent
+                android:action="android.settings.MANAGE_APP_ALL_FILES_ACCESS_PERMISSION"
+                android:data="@string/app_package_uri" />
+        </Preference>
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -154,6 +154,12 @@
             android:defaultValue="@string/settings_keep_deleted_default"
             android:key="@string/settings_keep_deleted_key"
             android:title="@string/settings_keep_deleted_label" />
+
+        <EditTextPreference
+            android:defaultValue="@string/settings_directory_picker_initial_path_default"
+            android:key="@string/settings_directory_picker_initial_path_key"
+            android:title="@string/settings_directory_picker_initial_path_label"
+            android:singleLine="true" />
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
This PR brings back support for (finding) files on external storage on Android 11 and later.

(Disclaimer: i'm more of an Android dabbler and though i tried my best at reading up on stuff as necessary, it is entirely possible that i missed something important.)

The commit names should be pretty self explanatory, and you can see all of the new features in the following 
<details><summary>Android 15 (emulator) screen recording.</summary>

https://github.com/user-attachments/assets/19ea9c45-4ad9-4370-8e51-6951983c1162

(Not terribly important, but in the video, `emulated/0` was listed as a single item under `/storage`. That differs from the current PR's version, where it is properly split into `emulated` followed by `0`.)
</details>

In principle, the commits for the initial path preference are orthogonal to the /storage discovery commit. And both of the latter seem to be orthogonal to the `MANAGE_EXTERNAL_STORAGE` permission.

From a user's perspective, the changes should be entirely backwards compatible.

(My Android Studio needed to upgrade its gradle plugin or whatever, which is mostly Android development black magic to me, but i suspect the [corresponding changes](https://github.com/J0J0/AudioAnchor/commit/2df06663ad1f656d66cb8df171eca6f6c57055d1) to tracked files should not be included in this PR ...(?))

Should fix https://github.com/flackbash/AudioAnchor/issues/111.